### PR TITLE
Fixes related to compiling on OSX

### DIFF
--- a/srf-ip-conn/client-demo/Makefile
+++ b/srf-ip-conn/client-demo/Makefile
@@ -1,5 +1,5 @@
 all: *.c *.h ../common/*
-	gcc -Wall -o client -I../.. -I../common *.c ../common/*
+	gcc -Wall -o client -I../.. -I../common *.c ../common/*.c
 
 clean:
 	rm client

--- a/srf-ip-conn/client-demo/client-sock.c
+++ b/srf-ip-conn/client-demo/client-sock.c
@@ -72,7 +72,7 @@ int client_sock_receive(void) {
 			if ((client_sock_received_packet.received_bytes = recvfrom(client_sock_fd, client_sock_received_packet.buf, sizeof(client_sock_received_packet.buf), 0, (struct sockaddr *)&from_addr, &addr_len)) == -1)
 				return -1;
 
-			printf("client-sock: got %u byte packet from %s:%u\n", client_sock_received_packet.received_bytes,
+			printf("client-sock: got %zd byte packet from %s:%u\n", client_sock_received_packet.received_bytes,
 					inet_ntop(from_addr.sa_family, sock_get_in_addr(&from_addr), s, sizeof(s)),
 					sock_get_port(&from_addr));
 			return client_sock_received_packet.received_bytes;

--- a/srf-ip-conn/client-demo/client-sock.h
+++ b/srf-ip-conn/client-demo/client-sock.h
@@ -32,7 +32,7 @@ DEALINGS IN THE SOFTWARE.
 
 typedef struct {
 	uint8_t buf[sizeof(srf_ip_conn_packet_t)];
-	uint16_t received_bytes;
+	ssize_t received_bytes;
 } client_sock_received_packet_t;
 
 extern client_sock_received_packet_t client_sock_received_packet;

--- a/srf-ip-conn/client-demo/packet.c
+++ b/srf-ip-conn/client-demo/packet.c
@@ -34,7 +34,7 @@ static void packet_process_token(void) {
 	srf_ip_conn_packet_t *packet = (srf_ip_conn_packet_t *)client_sock_received_packet.buf;
 
 	if (client_sock_received_packet.received_bytes != sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_token_payload_t)) {
-		printf("  packet is %u bytes, not %lu, ignoring\n", client_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_token_payload_t));
+		printf("  packet is %zd bytes, not %lu, ignoring\n", client_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_token_payload_t));
 		return;
 	}
 
@@ -45,7 +45,7 @@ static void packet_process_ack(void) {
 	srf_ip_conn_packet_t *packet = (srf_ip_conn_packet_t *)client_sock_received_packet.buf;
 
 	if (client_sock_received_packet.received_bytes != sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_ack_payload_t)) {
-		printf("  packet is %u bytes, not %lu, ignoring\n", client_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_ack_payload_t));
+		printf("  packet is %zd bytes, not %lu, ignoring\n", client_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_ack_payload_t));
 		return;
 	}
 	if (!srf_ip_conn_packet_hmac_check(client_token, CONFIG_PASSWORD, packet, sizeof(srf_ip_conn_ack_payload_t))) {
@@ -60,7 +60,7 @@ static void packet_process_nak(void) {
 	srf_ip_conn_packet_t *packet = (srf_ip_conn_packet_t *)client_sock_received_packet.buf;
 
 	if (client_sock_received_packet.received_bytes != sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_nak_payload_t)) {
-		printf("  packet is %u bytes, not %lu, ignoring\n", client_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_nak_payload_t));
+		printf("  packet is %zd bytes, not %lu, ignoring\n", client_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_nak_payload_t));
 		return;
 	}
 	if (!srf_ip_conn_packet_hmac_check(client_token, CONFIG_PASSWORD, packet, sizeof(srf_ip_conn_nak_payload_t))) {
@@ -75,7 +75,7 @@ static void packet_process_pong(void) {
 	srf_ip_conn_packet_t *packet = (srf_ip_conn_packet_t *)client_sock_received_packet.buf;
 
 	if (client_sock_received_packet.received_bytes != sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_pong_payload_t)) {
-		printf("  packet is %u bytes, not %lu, ignoring\n", client_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_pong_payload_t));
+		printf("  packet is %zd bytes, not %lu, ignoring\n", client_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_pong_payload_t));
 		return;
 	}
 	if (!srf_ip_conn_packet_hmac_check(client_token, CONFIG_PASSWORD, packet, sizeof(srf_ip_conn_pong_payload_t))) {
@@ -90,7 +90,7 @@ static void packet_process_raw(void) {
 	srf_ip_conn_packet_t *packet = (srf_ip_conn_packet_t *)client_sock_received_packet.buf;
 
 	if (client_sock_received_packet.received_bytes != sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_raw_payload_t)) {
-		printf("  packet is %u bytes, not %lu, ignoring\n", client_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_raw_payload_t));
+		printf("  packet is %zd bytes, not %lu, ignoring\n", client_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_raw_payload_t));
 		return;
 	}
 	if (!srf_ip_conn_packet_hmac_check(client_token, CONFIG_PASSWORD, packet, sizeof(srf_ip_conn_data_raw_payload_t))) {
@@ -106,7 +106,7 @@ static void packet_process_dmr(void) {
 	srf_ip_conn_packet_t *packet = (srf_ip_conn_packet_t *)client_sock_received_packet.buf;
 
 	if (client_sock_received_packet.received_bytes != sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_dmr_payload_t)) {
-		printf("  packet is %u bytes, not %lu, ignoring\n", client_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_dmr_payload_t));
+		printf("  packet is %zd bytes, not %lu, ignoring\n", client_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_dmr_payload_t));
 		return;
 	}
 	if (!srf_ip_conn_packet_hmac_check(client_token, CONFIG_PASSWORD, packet, sizeof(srf_ip_conn_data_dmr_payload_t))) {
@@ -122,7 +122,7 @@ static void packet_process_dstar(void) {
 	srf_ip_conn_packet_t *packet = (srf_ip_conn_packet_t *)client_sock_received_packet.buf;
 
 	if (client_sock_received_packet.received_bytes != sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_dstar_payload_t)) {
-		printf("  packet is %u bytes, not %lu, ignoring\n", client_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_dstar_payload_t));
+		printf("  packet is %zd bytes, not %lu, ignoring\n", client_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_dstar_payload_t));
 		return;
 	}
 	if (!srf_ip_conn_packet_hmac_check(client_token, CONFIG_PASSWORD, packet, sizeof(srf_ip_conn_data_dstar_payload_t))) {
@@ -138,7 +138,7 @@ static void packet_process_c4fm(void) {
 	srf_ip_conn_packet_t *packet = (srf_ip_conn_packet_t *)client_sock_received_packet.buf;
 
 	if (client_sock_received_packet.received_bytes != sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_c4fm_payload_t)) {
-		printf("  packet is %u bytes, not %lu, ignoring\n", client_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_c4fm_payload_t));
+		printf("  packet is %zd bytes, not %lu, ignoring\n", client_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_c4fm_payload_t));
 		return;
 	}
 	if (!srf_ip_conn_packet_hmac_check(client_token, CONFIG_PASSWORD, packet, sizeof(srf_ip_conn_data_c4fm_payload_t))) {

--- a/srf-ip-conn/server-demo/Makefile
+++ b/srf-ip-conn/server-demo/Makefile
@@ -1,5 +1,5 @@
 all: *.c *.h ../common/*
-	gcc -Wall -o server -I../.. -I../common *.c ../common/*
+	gcc -Wall -o server -I../.. -I../common *.c ../common/*.c
 
 clean:
 	rm server

--- a/srf-ip-conn/server-demo/packet.c
+++ b/srf-ip-conn/server-demo/packet.c
@@ -45,7 +45,7 @@ static void packet_process_login(void) {
 	uint8_t i;
 
 	if (server_sock_received_packet.received_bytes != sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_login_payload_t)) {
-		printf("  packet is %u bytes, not %lu, ignoring\n", server_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_login_payload_t));
+		printf("  packet is %zd bytes, not %lu, ignoring\n", server_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_login_payload_t));
 		return;
 	}
 
@@ -73,7 +73,7 @@ static void packet_process_auth(void) {
 	}
 
 	if (server_sock_received_packet.received_bytes != sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_auth_payload_t)) {
-		printf("  packet is %u bytes, not %lu, ignoring\n", server_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_auth_payload_t));
+		printf("  packet is %zd bytes, not %lu, ignoring\n", server_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_auth_payload_t));
 		return;
 	}
 
@@ -125,7 +125,7 @@ static flag_t packet_process_config(void) {
 	uint8_t i;
 
 	if (server_sock_received_packet.received_bytes != sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_config_payload_t)) {
-		printf("  packet is %u bytes, not %lu, ignoring\n", server_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_config_payload_t));
+		printf("  packet is %zd bytes, not %lu, ignoring\n", server_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_config_payload_t));
 		return 0;
 	}
 	if (!server_client_is_logged_in(&server_sock_received_packet.from_addr)) {
@@ -155,7 +155,7 @@ static flag_t packet_process_ping(void) {
 	uint8_t i;
 
 	if (server_sock_received_packet.received_bytes != sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_ping_payload_t)) {
-		printf("  packet is %u bytes, not %lu, ignoring\n", server_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_ping_payload_t));
+		printf("  packet is %zd bytes, not %lu, ignoring\n", server_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_ping_payload_t));
 		return 0;
 	}
 	if (!server_client_is_logged_in(&server_sock_received_packet.from_addr)) {
@@ -182,7 +182,7 @@ static void packet_process_close(void) {
 	uint8_t i;
 
 	if (server_sock_received_packet.received_bytes != sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_close_payload_t)) {
-		printf("  packet is %u bytes, not %lu, ignoring\n", server_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_close_payload_t));
+		printf("  packet is %zd bytes, not %lu, ignoring\n", server_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_close_payload_t));
 		return;
 	}
 	if (!server_client_is_logged_in(&server_sock_received_packet.from_addr)) {
@@ -209,7 +209,7 @@ static flag_t packet_process_raw(void) {
 	srf_ip_conn_packet_t *packet = (srf_ip_conn_packet_t *)server_sock_received_packet.buf;
 
 	if (server_sock_received_packet.received_bytes != sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_raw_payload_t)) {
-		printf("  packet is %u bytes, not %lu, ignoring\n", server_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_raw_payload_t));
+		printf("  packet is %zd bytes, not %lu, ignoring\n", server_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_raw_payload_t));
 		return 0;
 	}
 	if (!server_client_is_logged_in(&server_sock_received_packet.from_addr)) {
@@ -231,7 +231,7 @@ static flag_t packet_process_dmr(void) {
 	srf_ip_conn_packet_t *packet = (srf_ip_conn_packet_t *)server_sock_received_packet.buf;
 
 	if (server_sock_received_packet.received_bytes != sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_dmr_payload_t)) {
-		printf("  packet is %u bytes, not %lu, ignoring\n", server_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_dmr_payload_t));
+		printf("  packet is %zd bytes, not %lu, ignoring\n", server_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_dmr_payload_t));
 		return 0;
 	}
 	if (!server_client_is_logged_in(&server_sock_received_packet.from_addr)) {
@@ -253,7 +253,7 @@ static flag_t packet_process_dstar(void) {
 	srf_ip_conn_packet_t *packet = (srf_ip_conn_packet_t *)server_sock_received_packet.buf;
 
 	if (server_sock_received_packet.received_bytes != sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_dstar_payload_t)) {
-		printf("  packet is %u bytes, not %lu, ignoring\n", server_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_dstar_payload_t));
+		printf("  packet is %zd bytes, not %lu, ignoring\n", server_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_dstar_payload_t));
 		return 0;
 	}
 	if (!server_client_is_logged_in(&server_sock_received_packet.from_addr)) {
@@ -275,7 +275,7 @@ static flag_t packet_process_c4fm(void) {
 	srf_ip_conn_packet_t *packet = (srf_ip_conn_packet_t *)server_sock_received_packet.buf;
 
 	if (server_sock_received_packet.received_bytes != sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_c4fm_payload_t)) {
-		printf("  packet is %u bytes, not %lu, ignoring\n", server_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_c4fm_payload_t));
+		printf("  packet is %zd bytes, not %lu, ignoring\n", server_sock_received_packet.received_bytes, sizeof(srf_ip_conn_packet_header_t)+sizeof(srf_ip_conn_data_c4fm_payload_t));
 		return 0;
 	}
 	if (!server_client_is_logged_in(&server_sock_received_packet.from_addr)) {

--- a/srf-ip-conn/server-demo/server-sock.c
+++ b/srf-ip-conn/server-demo/server-sock.c
@@ -70,7 +70,7 @@ int server_sock_receive(void) {
 			if ((server_sock_received_packet.received_bytes = recvfrom(server_sock_fd, server_sock_received_packet.buf, sizeof(server_sock_received_packet.buf), 0, (struct sockaddr *)&server_sock_received_packet.from_addr, &addr_len)) == -1)
 				return -1;
 
-			printf("server-sock: got %u byte packet from %s:%u\n", server_sock_received_packet.received_bytes,
+			printf("server-sock: got %zd byte packet from %s:%u\n", server_sock_received_packet.received_bytes,
 					inet_ntop(server_sock_received_packet.from_addr.sa_family, sock_get_in_addr(&server_sock_received_packet.from_addr), s, sizeof(s)),
 					sock_get_port(&server_sock_received_packet.from_addr));
 			return server_sock_received_packet.received_bytes;

--- a/srf-ip-conn/server-demo/server-sock.h
+++ b/srf-ip-conn/server-demo/server-sock.h
@@ -32,7 +32,7 @@ DEALINGS IN THE SOFTWARE.
 
 typedef struct {
 	uint8_t buf[sizeof(srf_ip_conn_packet_t)];
-	uint16_t received_bytes;
+	ssize_t received_bytes;
 	struct sockaddr from_addr;
 } server_sock_received_packet_t;
 


### PR DESCRIPTION
When compiling on OSX, the Makefile needed to be changed because clang's emulation of gcc was not happy with the 'common/*' inclusion.

In addition, clang giving a warning that the conditional checks where the output of recvfrom() was assigned to the unsigned-integer received_bytes and then checked against -1...and thus would have no effect.